### PR TITLE
Cross-Slice Dependencies in Restoring Backups

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "size-limit": "^4.9.0",
     "ts-jest": "^26.4.4",
     "tsdx": "^0.14.1",
-    "tslib": "^2.0.3",
+    "tslib": "^2.3.1",
     "typescript": "^4.1.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
   "size-limit": [
     {
       "path": "dist/redux-flexible-backup.cjs.production.min.js",
-      "limit": "10 KB"
+      "limit": "25 KB"
     },
     {
       "path": "dist/redux-flexible-backup.esm.js",
-      "limit": "10 KB"
+      "limit": "25 KB"
     }
   ],
   "devDependencies": {

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -1,4 +1,5 @@
-import { createBackup, loadBackup } from '../src/backup';
+import { createBackup, DependencyLoader, loadBackup } from '../src/backup';
+import { CopySliceBackupInterface } from '../src/def';
 
 describe('A Simple State', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -102,5 +103,96 @@ describe('A state in a state', () => {
     const restored = loadBackup({}, stateBackup, backup);
 
     expect(restored).toEqual(state);
+  });
+});
+
+describe('A state whose slices update a shared number while loading', () => {
+  interface State {
+    a: string;
+    b: string;
+    shared: number;
+    [i: string]: any;
+  }
+
+  const aBackupInterface = {
+    save: (state: string) => state,
+    load: (data: string, deps: DependencyLoader<State>) => {
+      const shared = deps.needs('shared');
+      deps.update('shared', shared + 1);
+      return data;
+    },
+  };
+
+  const bBackupInterface = {
+    save: (state: number) => state,
+    load: (data: number) => data,
+  };
+
+  const backupInterface = {
+    a: aBackupInterface,
+    b: aBackupInterface,
+    shared: bBackupInterface,
+  };
+
+  test('Basic save and restore', () => {
+    const state: State = { a: 'a data', b: 'b data', shared: 42 };
+    const backup = createBackup(state, backupInterface);
+    expect(backup.shared).toBe(42);
+
+    const newState = loadBackup({}, backupInterface, backup);
+    expect(newState).toBeDefined();
+    expect(newState.shared).toBe(state.shared + 2);
+  });
+});
+
+describe('A state whose slices need to rebuild from a shared slice', () => {
+  interface State {
+    a: string;
+    b: string;
+    shared: {
+      a: number;
+      b: number;
+    };
+    [i: string]: any;
+  }
+
+  const aBackupInterface = {
+    save: (state: string) => state[0],
+    load: (_data: string, deps: DependencyLoader<State>) => {
+      const ret = deps.needs('shared').a.toString();
+      deps.update('shared', { a: 0 });
+      return ret;
+    },
+  };
+
+  const bBackupInterface = {
+    save: (state: string) => state[0],
+    load: (_data: string, deps: DependencyLoader<State>) => {
+      const ret = deps.needs('shared').b.toString();
+      deps.update('shared', { b: 1 });
+      return ret;
+    },
+  };
+
+  const sharedBackupInterface = CopySliceBackupInterface;
+
+  const backupInterface = {
+    a: aBackupInterface,
+    b: bBackupInterface,
+    shared: sharedBackupInterface,
+  };
+
+  test('Basic save and restore', () => {
+    const state: State = { a: '3', b: '6', shared: { a: 3, b: 6 } };
+    const backup = createBackup(state, backupInterface);
+
+    const newState = loadBackup({}, backupInterface, backup);
+    expect(newState).toBeDefined();
+    expect(newState.a).toBe(state.a);
+    expect(newState.b).toBe(state.b);
+    expect(newState.shared).toMatchObject({
+      a: 0,
+      b: 1,
+    });
   });
 });

--- a/test/slice.test.ts
+++ b/test/slice.test.ts
@@ -22,7 +22,10 @@ test('Can create backup interface from a slice definition', () => {
   // Test it
   const saved = backupInterface.save(initialState);
   expect(saved).toBe('4dd');
-  const loaded = backupInterface.load(saved);
+  const loaded = backupInterface.load(saved, {
+    needs: () => 0,
+    update: () => {},
+  });
   expect(loaded?.num).toBe(4);
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8547,10 +8547,10 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
-  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
+tslib@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
Allow the loading of one slice in a state from backup to depend on data loaded from a sibling slice, even potentially modifying that sibling in the course of loading.

This is done by a new argument passed into the slice loader of type `DependencyLoader` which supports the `needs` and `update` function. `needs` allows you to declare a dependency on a sibling slice (and returns the fully loaded value of that slice) and `update` allows you to modify that sibling. Loading order is dynamically shifted to allow for these dependencies and an exception is thrown if you create a circular dependency.